### PR TITLE
fix missing headers and issues with old FITS files for a22 and e3

### DIFF
--- a/relbase.c
+++ b/relbase.c
@@ -18,6 +18,8 @@
 #include "relbase.h"
 
 
+int rel_nk_table_ng;
+
 // new CACHE routines
 cnode* cache_relbase = NULL;
 cnode* cache_syspar  = NULL;
@@ -78,8 +80,10 @@ char* get_filename(int * status){
 	int mdot_type = current_mdot_type;
 	int def_par_type = current_def_par_type;
 	// printf("%d %d\n", def_par_type, mdot_type);
+	rel_nk_table_ng=RELNKTABLE_NG_OLD;
 	if (mdot_type == 0) {
 		if (def_par_type == 1) {
+		        rel_nk_table_ng=RELNKTABLE_NG;
 			return NK_FILENAME_1;
 		}
 		if (def_par_type == 2) {

--- a/relbase.h
+++ b/relbase.h
@@ -45,7 +45,7 @@
 #define version_dev_nk ""
 
 /** path to all RELXILL tables */
-#define RELXILL_TABLE_PATH "/media/linux/relxill_nk_v1.6.3"
+#define RELXILL_TABLE_PATH "/Users/askarabd/Documents/fudan/FITS"
 
 /** dimensions of the RELLINE table */
 #define RELTABLE_NA 25

--- a/relbase.h
+++ b/relbase.h
@@ -45,7 +45,7 @@
 #define version_dev_nk ""
 
 /** path to all RELXILL tables */
-#define RELXILL_TABLE_PATH "/Users/askarabd/Documents/fudan/FITS"
+#define RELXILL_TABLE_PATH "/media/linux/relxill_nk_v1.6.3"
 
 /** dimensions of the RELLINE table */
 #define RELTABLE_NA 25
@@ -125,6 +125,7 @@
 #define RELNKTABLE_NMU0 22
 #define RELNKTABLE_NR 100
 #define RELNKTABLE_NG 40
+#define RELNKTABLE_NG_OLD 20
 
 
 /****** TYPE DEFINITIONS ******/

--- a/rellp.c
+++ b/rellp.c
@@ -17,6 +17,7 @@
 */
 
 #include "rellp.h"
+#include "relrc.h"
 
 // lpTable* cached_lp_table = NULL;
 lpnkTable* cached_lp_table = NULL;

--- a/relrc.h
+++ b/relrc.h
@@ -8,6 +8,7 @@
 
 void get_emis_ring_corona(relParam* param, double* emis, double* re, int n_r, int* status);
 
+void get_emis_disk_corona(relParam* param, double* emis, double* re, int n_r, int* status);
 
 
 #endif /* RELRC_H_ */

--- a/reltable.c
+++ b/reltable.c
@@ -20,6 +20,7 @@
 #include "time.h"
 
 extern int loaded_file_def_par;
+extern int rel_nk_table_ng;
 
 static relDat* new_relDat(int nr, int ng, int* status){
 	relDat* dat = (relDat*) malloc (sizeof(relDat));
@@ -248,7 +249,7 @@ static relDat* load_single_relDat(fitsfile* fptr, char* extname, int nhdu, int* 
 	}
 
 	// allocate the memory for the table
-	relDat* dat = new_relDat(RELNKTABLE_NR,RELNKTABLE_NG,status);
+	relDat* dat = new_relDat(RELNKTABLE_NR,rel_nk_table_ng,status);
 	CHECK_STATUS_RET(*status,NULL);
 
 	// now load the table column by column
@@ -265,13 +266,13 @@ static relDat* load_single_relDat(fitsfile* fptr, char* extname, int nhdu, int* 
     CHECK_STATUS_RET(*status,dat);
 
     // (2) and finally the 2D columns
-    load_single_relDat_2dcol(fptr,dat->trff2,RELNKTABLE_NR,RELNKTABLE_NG,colnum_trff2,status);
+    load_single_relDat_2dcol(fptr,dat->trff2,RELNKTABLE_NR,rel_nk_table_ng,colnum_trff2,status);
     CHECK_STATUS_RET(*status,dat);
-    load_single_relDat_2dcol(fptr,dat->trff1,RELNKTABLE_NR,RELNKTABLE_NG,colnum_trff1,status);
+    load_single_relDat_2dcol(fptr,dat->trff1,RELNKTABLE_NR,rel_nk_table_ng,colnum_trff1,status);
     CHECK_STATUS_RET(*status,dat);
-    load_single_relDat_2dcol(fptr,dat->cosne1,RELNKTABLE_NR,RELNKTABLE_NG,colnum_cosne1,status);
+    load_single_relDat_2dcol(fptr,dat->cosne1,RELNKTABLE_NR,rel_nk_table_ng,colnum_cosne1,status);
     CHECK_STATUS_RET(*status,dat);
-    load_single_relDat_2dcol(fptr,dat->cosne2,RELNKTABLE_NR,RELNKTABLE_NG,colnum_cosne2,status);
+    load_single_relDat_2dcol(fptr,dat->cosne2,RELNKTABLE_NR,rel_nk_table_ng,colnum_cosne2,status);
     CHECK_STATUS_RET(*status,dat);
 
     return dat;
@@ -377,7 +378,7 @@ void read_rellinenk_table(char* filename, relnkTable** inp_tab, int* status){
 		// 	free_relnkTable(tab);
 		// 	tab = NULL;
 		// }
-		tab = new_relnkTable(RELNKTABLE_NA,RELNKTABLE_NMU0,RELNKTABLE_NR,RELNKTABLE_NG,RELTABLE_NDEFPAR,status);
+		tab = new_relnkTable(RELNKTABLE_NA,RELNKTABLE_NMU0,RELNKTABLE_NR,rel_nk_table_ng,RELTABLE_NDEFPAR,status);
 		CHECK_STATUS_BREAK(*status);
 
 		// should be set by previous routine

--- a/reltable.c
+++ b/reltable.c
@@ -600,7 +600,7 @@ double h_k[20] = {1.1589, 1.89, 2.13397, 2.24539, 2.27, 2.23798, 2.19106, 2.1139
 double hg[30];
 int ci=-1;
 
-lpDat* load_single_lp_nk_Dat(fitsfile* fptr, int n_h, int n_rad, int i, int j, int rownum, double defpar[], int nhdu, int* status){
+lpDat* load_single_lp_nk_Dat(fitsfile* fptr, int n_h, int n_rad, int i, int j, int rownum, float defpar[], int nhdu, int* status){
 	lpDat* dat = new_lpDat(n_h,n_rad,status);
 	CHECK_MALLOC_RET_STATUS(dat,status,NULL);
 

--- a/reltable.h
+++ b/reltable.h
@@ -168,5 +168,6 @@ void check_rcTable_cache(char* fname, rcTable* tab, int* ind, int* status);
 
 fitsfile* open_rc_tab(char* filename, int* status);
 
+void init_rc_table(char* filename, rcTable** inp_tab, int* status);
 
 #endif /* RELTABLE_H_ */

--- a/relutility.h
+++ b/relutility.h
@@ -76,6 +76,8 @@ void get_lin_grid(double* ener, int n_ener, double emin, double emax);
 /* get the current version number */
 void get_version_number(char** vstr, int* status);
 
+void get_version_number_nk(char** vstr, int* status);
+
 /* print relxill error message */
 void relxill_error(const char* const func, const char* const msg, int* status);
 
@@ -180,6 +182,8 @@ double density_ss73_zone_a(double radius, double rms);
 
 /** is is a model for which we want to calculate the ionization gradient? **/
 int is_iongrad_model(int ion_type, int ion_grad_type);
+
+int is_densgrad_model(int rmodel_type, int xmodel_type, int ion_grad_type );
 
 void free_ion_grad(ion_grad* ion);
 ion_grad* new_ion_grad(double* r, int n, int* status);


### PR DESCRIPTION
fix missing header issues and function declaration issues with gcc (GCC) 14.2.1 20240912.

`relutility.h`: declare functions in th header:
```
int is_densgrad_model(int rmodel_type, int xmodel_type, int ion_grad_type );

void get_version_number_nk(char** vstr, int* status);
```
`rellp.c`: add a missing header:
`#include "relrc.h"`

`relrc.h`: declare a function in th header:
`void get_emis_disk_corona(relParam* param, double* emis, double* re, int n_r, int* status);`

`reltable.h`: declare a function in th header:
`void init_rc_table(char* filename, rcTable** inp_tab, int* status);`

`reltable.c`: change from
`lpDat* load_single_lp_nk_Dat(fitsfile* fptr, int n_h, int n_rad, int i, int j, int rownum, double defpar[], int nhdu, int* status)`
to
`lpDat* load_single_lp_nk_Dat(fitsfile* fptr, int n_h, int n_rad, int i, int j, int rownum, float defpar[], int nhdu, int* status)`